### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/source/src/main/webapp/DatabaseMaintenance.jsp
+++ b/source/src/main/webapp/DatabaseMaintenance.jsp
@@ -81,13 +81,13 @@
                     out.print("</b></td>");
 
                     // Start to build the SQL Script here.
-                    SQLInstruction = new ArrayList<String>();
+                    SQLInstruction = new ArrayList<>();
                     appContext = WebApplicationContextUtils.getWebApplicationContext(this.getServletContext());
                     IDatabaseVersioningService DatabaseVersionService = appContext.getBean(IDatabaseVersioningService.class);
                     SQLInstruction = DatabaseVersionService.getSQLScript();
 
                     // Initialize the array that will receive the RC of every execution.
-                    SQLRC = new ArrayList<String>();
+                    SQLRC = new ArrayList<>();
 
                     // Calculate the version that will be updated. Version correspond directly to the size of the arry (ie the number of SQL to execute)
                     NewVersion = SQLInstruction.size();

--- a/source/src/main/webapp/Documentation.jsp
+++ b/source/src/main/webapp/Documentation.jsp
@@ -45,10 +45,10 @@
 
         String Title = "";
         List<String> TitleList;
-        TitleList = new ArrayList<String>();
+        TitleList = new ArrayList<>();
         String Doc = "";
         List<String> DocList;
-        DocList = new ArrayList<String>();
+        DocList = new ArrayList<>();
 
         if (DocValue_isdefined == false) {
 

--- a/source/src/main/webapp/ReportingExecution.jsp
+++ b/source/src/main/webapp/ReportingExecution.jsp
@@ -440,7 +440,7 @@
 %>
 
 <%
-    TreeMap<String, String> options = new TreeMap<String, String>();
+    TreeMap<String, String> options = new TreeMap<>();
 
     User usr = userService.findUserByKey(request.getUserPrincipal().getName());
     String reportingFavorite = "ReportingExecution.jsp?"+usr.getReportingFavorite();

--- a/source/src/main/webapp/RunTestsSearchFilters.jsp
+++ b/source/src/main/webapp/RunTestsSearchFilters.jsp
@@ -44,7 +44,7 @@
         <%@ include file="include/function.jsp" %>
             <%
                 final Logger LOG = Logger.getLogger(this.getClass());
-                TreeMap<String, String> options = new TreeMap<String, String>();
+                TreeMap<String, String> options = new TreeMap<>();
 
                 IInvariantService invariantService = appContext.getBean(InvariantService.class);
                 ITestService testService = appContext.getBean(ITestService.class);

--- a/source/src/main/webapp/TestBatteryTestCaseSearch.jsp
+++ b/source/src/main/webapp/TestBatteryTestCaseSearch.jsp
@@ -41,7 +41,7 @@
         <%@ include file="include/function.jsp" %>
             <%
                 final Logger LOG = Logger.getLogger(this.getClass());
-                TreeMap<String, String> options = new TreeMap<String, String>();
+                TreeMap<String, String> options = new TreeMap<>();
 
                 IInvariantService invariantService = appContext.getBean(InvariantService.class);
                 ITestService testService = appContext.getBean(ITestService.class);

--- a/source/src/main/webapp/TestCase.jsp
+++ b/source/src/main/webapp/TestCase.jsp
@@ -1033,7 +1033,7 @@
 
                                     <%
                                         int incrementStep = 0;
-                                        List<String> listOfImportedProperties = new ArrayList<String>();
+                                        List<String> listOfImportedProperties = new ArrayList<>();
                                         List<TestCaseStep> tcsList = tcsService.getListOfSteps(test, testcase);
                                         for (TestCaseStep tcs : tcsList) {
                                             incrementStep++;

--- a/source/src/main/webapp/TestCaseSearchNew.jsp
+++ b/source/src/main/webapp/TestCaseSearchNew.jsp
@@ -112,7 +112,7 @@ if (freeText !== null) {
         <%@ include file="include/header.jsp" %>
         <%
             final Logger LOG = Logger.getLogger(this.getClass());
-            TreeMap<String, String> options = new TreeMap<String, String>();
+            TreeMap<String, String> options = new TreeMap<>();
 
             IInvariantService invariantService = appContext.getBean(InvariantService.class);
             ITestService testService = appContext.getBean(ITestService.class);

--- a/source/src/main/webapp/TestPerApplication.jsp
+++ b/source/src/main/webapp/TestPerApplication.jsp
@@ -133,7 +133,7 @@
      <input id="systemSelected" value="<%=MySystem%>" style="display:none">
         <%
             if (filterApp){
-                appList=new ArrayList<Application>();
+                appList= new ArrayList<>();
                 appList.add(applicationService.convert(applicationService.readByKey(appSel)));
             }
 

--- a/source/src/main/webapp/include/header.jsp
+++ b/source/src/main/webapp/include/header.jsp
@@ -183,7 +183,7 @@
                                 MySystem = MyUserobj.getDefaultSystem();
                             } else {
                                 if (!(MyUserobj.getDefaultSystem().equals(MySystem))) {
-                                    List<String> systems = new ArrayList<String>();
+                                    List<String> systems = new ArrayList<>();
                                     for (UserSystem us : MyUserobj.getUserSystems()) {
                                         systems.add(us.getSystem());
                                     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.