### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/source/src/main/java/org/cerberus/util/DateUtil.java
+++ b/source/src/main/java/org/cerberus/util/DateUtil.java
@@ -41,7 +41,10 @@ public class DateUtil {
      */
     public static final String DATE_FORMAT_TIMESTAMP = "yyyyMMddHHmmssSSS";
 
-    
+    private DateUtil() {
+    }
+
+
     /**
      * @param nbMinutes
      * @return a String that contains a timestamp + the nb of minutes sent as a

--- a/source/src/main/java/org/cerberus/util/FileUtil.java
+++ b/source/src/main/java/org/cerberus/util/FileUtil.java
@@ -24,6 +24,9 @@ package org.cerberus.util;
  * @author FNogueira
  */
 public class FileUtil {
+    private FileUtil() {
+    }
+
     /**
      * Generate ScreenshotFileName using 2 method : If pictureName is not null,
      * use it directly. If picture name is null, generate name using test,

--- a/source/src/main/java/org/cerberus/util/GraphicHelper.java
+++ b/source/src/main/java/org/cerberus/util/GraphicHelper.java
@@ -31,6 +31,9 @@ import org.json.JSONObject;
 public class GraphicHelper {
     private static final Logger LOGGER = Logger.getLogger(GraphicHelper.class);
 
+    private GraphicHelper() {
+    }
+
     /**
      *
      * @param label axis label

--- a/source/src/main/java/org/cerberus/util/SqlUtil.java
+++ b/source/src/main/java/org/cerberus/util/SqlUtil.java
@@ -28,6 +28,9 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class SqlUtil {
 
+    private SqlUtil() {
+    }
+
     /**
      *
      * @param obj List of generic object that have a toString Method

--- a/source/src/main/java/org/cerberus/util/answer/AnswerUtil.java
+++ b/source/src/main/java/org/cerberus/util/answer/AnswerUtil.java
@@ -29,6 +29,9 @@ import org.cerberus.enums.MessageEventEnum;
  */
 public class AnswerUtil {
 
+    private AnswerUtil() {
+    }
+
     public static String createGenericErrorAnswer() {
         MessageEvent msg = new MessageEvent(MessageEventEnum.DATA_OPERATION_ERROR_UNEXPECTED);
         StringBuilder errorMessage = new StringBuilder();

--- a/source/src/main/java/org/cerberus/util/answer/MessageEventUtil.java
+++ b/source/src/main/java/org/cerberus/util/answer/MessageEventUtil.java
@@ -36,6 +36,9 @@ public class MessageEventUtil {
     private static final String DELETE_OPERATION = "Delete";
     private static final String SELECT_OPERATION = "Select";
 
+    private MessageEventUtil() {
+    }
+
     private static MessageEvent createUnexpectedErrorMessageDAO(String operation) {
         MessageEvent msg = new MessageEvent(MessageEventEnum.DATA_OPERATION_ERROR_UNEXPECTED);
         msg.setDescription(msg.getDescription().replace("%DESCRIPTION%", "Unable to execute " + operation + " operation(s)!"));

--- a/source/src/main/java/org/cerberus/util/servlet/ServletUtil.java
+++ b/source/src/main/java/org/cerberus/util/servlet/ServletUtil.java
@@ -32,6 +32,9 @@ public final class ServletUtil {
 
     private static final long DEFAULT_WAIT_MS = 20;
 
+    private ServletUtil() {
+    }
+
     /**
      * This method should be called in every servlet call. That allow transversal action to be performed in debug mode.
      * Actions can be for example to delay every called to simulate a slow response time and validate the behaviour of the GUI.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.