### PR TITLE
"toString()" should never be called on a String object

### DIFF
--- a/source/src/main/java/org/cerberus/crud/dao/impl/BuildRevisionBatchDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/BuildRevisionBatchDAO.java
@@ -372,7 +372,7 @@ public class BuildRevisionBatchDAO implements IBuildRevisionBatchDAO {
 
         // Debug message on SQL.
         if (LOG.isDebugEnabled()) {
-            LOG.debug("SQL : " + query.toString());
+            LOG.debug("SQL : " + query);
         }
         Connection connection = this.databaseSpring.connect();
         try {

--- a/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvParam_logDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvParam_logDAO.java
@@ -389,7 +389,7 @@ public class CountryEnvParam_logDAO implements ICountryEnvParam_logDAO {
 
         // Debug message on SQL.
         if (LOG.isDebugEnabled()) {
-            LOG.debug("SQL : " + query.toString());
+            LOG.debug("SQL : " + query);
         }
         Connection connection = this.databaseSpring.connect();
         try {

--- a/source/src/main/java/org/cerberus/crud/dao/impl/InvariantDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/InvariantDAO.java
@@ -429,7 +429,7 @@ public class InvariantDAO implements IInvariantDAO {
         
         String query = "SELECT count(*) FROM invariant i  WHERE 1=1 " + searchSQL.toString();
         
-        MyLogger.log(InvariantDAO.class.getName(), Level.DEBUG, query.toString());
+        MyLogger.log(InvariantDAO.class.getName(), Level.DEBUG, query);
 
         Connection connection = this.databaseSpring.connect();
         try {

--- a/source/src/main/java/org/cerberus/crud/dao/impl/ProjectDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/ProjectDAO.java
@@ -302,7 +302,7 @@ public class ProjectDAO implements IProjectDAO {
 
         // Debug message on SQL.
         if (LOG.isDebugEnabled()) {
-            LOG.debug("SQL : " + query.toString());
+            LOG.debug("SQL : " + query);
         }
         Connection connection = this.databaseSpring.connect();
         try {
@@ -343,7 +343,7 @@ public class ProjectDAO implements IProjectDAO {
 
         // Debug message on SQL.
         if (LOG.isDebugEnabled()) {
-            LOG.debug("SQL : " + query.toString());
+            LOG.debug("SQL : " + query);
         }
         Connection connection = this.databaseSpring.connect();
         try {

--- a/source/src/main/java/org/cerberus/crud/dao/impl/TestCaseStepActionControlDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/TestCaseStepActionControlDAO.java
@@ -310,7 +310,7 @@ public class TestCaseStepActionControlDAO implements ITestCaseStepActionControlD
 
         Connection connection = this.databaseSpring.connect();
         try {
-            PreparedStatement preStat = connection.prepareStatement(query.toString());
+            PreparedStatement preStat = connection.prepareStatement(query);
             try {
                 preStat.setString(1, testCaseStepActionControl.getTest());
                 preStat.setString(2, testCaseStepActionControl.getTestCase());

--- a/source/src/main/java/org/cerberus/crud/entity/TestCaseExecutionData.java
+++ b/source/src/main/java/org/cerberus/crud/entity/TestCaseExecutionData.java
@@ -188,7 +188,7 @@ public class TestCaseExecutionData {
 
     @Override
     public String toString() {
-        return "TestCaseExecutionData{" + "id=" + id + ", property=" + property + ", value=" + value + ", type=" + type + ", value1=" + value1 + ", value2=" + value2 + ", RC=" + RC + ", rMessage=" + rMessage.toString() + ", start=" + start + ", end=" + end + ", startLong=" + startLong + ", endLong=" + endLong + ", propertyResultMessage=" + propertyResultMessage.toString() + ", executionResultMessage=" + executionResultMessage.toString() + ", stopExecution=" + stopExecution + '}';
+        return "TestCaseExecutionData{" + "id=" + id + ", property=" + property + ", value=" + value + ", type=" + type + ", value1=" + value1 + ", value2=" + value2 + ", RC=" + RC + ", rMessage=" + rMessage + ", start=" + start + ", end=" + end + ", startLong=" + startLong + ", endLong=" + endLong + ", propertyResultMessage=" + propertyResultMessage.toString() + ", executionResultMessage=" + executionResultMessage + ", stopExecution=" + stopExecution + '}';
     }
     
     


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1858 - “"toString()" should never be called on a String object”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1858
Please let me know if you have any questions.
Ayman Abdelghany.