### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/source/src/main/java/org/cerberus/crud/dao/impl/CampaignContentDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/CampaignContentDAO.java
@@ -313,7 +313,7 @@ public class CampaignContentDAO implements ICampaignContentDAO {
 
     @Override
     public boolean updateCampaignContent(CampaignContent campaignContent) {
-        final StringBuffer query = new StringBuffer("UPDATE `campaigncontent` SET campaign=?, testbattery=? WHERE campaigncontentID=?");
+        final StringBuilder query = new StringBuilder("UPDATE `campaigncontent` SET campaign=?, testbattery=? WHERE campaigncontentID=?");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -345,7 +345,7 @@ public class CampaignContentDAO implements ICampaignContentDAO {
 
     @Override
     public boolean createCampaignContent(CampaignContent campaignContent) {
-        final StringBuffer query = new StringBuffer("INSERT INTO `campaigncontent` (`campaign`, `testbattery`) VALUES (?, ?)");
+        final StringBuilder query = new StringBuilder("INSERT INTO `campaigncontent` (`campaign`, `testbattery`) VALUES (?, ?)");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -376,7 +376,7 @@ public class CampaignContentDAO implements ICampaignContentDAO {
 
     @Override
     public boolean deleteCampaignContent(CampaignContent campaignContent) {
-        final StringBuffer query = new StringBuffer("DELETE FROM `campaigncontent` WHERE campaigncontentID=?");
+        final StringBuilder query = new StringBuilder("DELETE FROM `campaigncontent` WHERE campaigncontentID=?");
 
         Connection connection = this.databaseSpring.connect();
         try {

--- a/source/src/main/java/org/cerberus/crud/dao/impl/CampaignDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/CampaignDAO.java
@@ -200,7 +200,7 @@ public class CampaignDAO implements ICampaignDAO {
     @Override
     public List<Campaign> findCampaignByCriteria(Integer campaignID, String campaign, String description) throws CerberusException {
         boolean throwEx = false;
-        final StringBuffer query = new StringBuffer("SELECT * FROM campaign c WHERE 1=1 ");
+        final StringBuilder query = new StringBuilder("SELECT * FROM campaign c WHERE 1=1 ");
 
         if (campaignID != null) {
             query.append(" AND c.campaignID = ?");
@@ -269,7 +269,7 @@ public class CampaignDAO implements ICampaignDAO {
 
     @Override
     public boolean updateCampaign(Campaign campaign) {
-        final StringBuffer query = new StringBuffer("UPDATE `campaign` SET campaign=?, Description=? WHERE campaignID=?");
+        final StringBuilder query = new StringBuilder("UPDATE `campaign` SET campaign=?, Description=? WHERE campaignID=?");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -301,7 +301,7 @@ public class CampaignDAO implements ICampaignDAO {
 
     @Override
     public boolean createCampaign(Campaign campaign) {
-        final StringBuffer query = new StringBuffer("INSERT INTO `campaign` (`campaign`, `Description`) VALUES (?, ?)");
+        final StringBuilder query = new StringBuilder("INSERT INTO `campaign` (`campaign`, `Description`) VALUES (?, ?)");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -332,7 +332,7 @@ public class CampaignDAO implements ICampaignDAO {
 
     @Override
     public boolean deleteCampaign(Campaign campaign) {
-        final StringBuffer query = new StringBuffer("DELETE FROM `campaign` WHERE campaignID=?");
+        final StringBuilder query = new StringBuilder("DELETE FROM `campaign` WHERE campaignID=?");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -371,7 +371,7 @@ public class CampaignDAO implements ICampaignDAO {
     @Override
     public List<TestCaseWithExecution> getCampaignTestCaseExecutionForEnvCountriesBrowserTag(String tag) throws CerberusException {
         boolean throwEx = false;
-        final StringBuffer query = new StringBuffer("select * from ( select tc.*, tce.Start, tce.End, tce.ID as statusExecutionID, tce.ControlStatus, tce.ControlMessage, tce.Environment, tce.Country, tce.Browser ")
+        final StringBuilder query = new StringBuilder("select * from ( select tc.*, tce.Start, tce.End, tce.ID as statusExecutionID, tce.ControlStatus, tce.ControlMessage, tce.Environment, tce.Country, tce.Browser ")
                 .append("from testcase tc ")
                 .append("left join testcaseexecution tce ")
                 .append("on tce.Test = tc.Test ")

--- a/source/src/main/java/org/cerberus/crud/dao/impl/CampaignParameterDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/CampaignParameterDAO.java
@@ -197,7 +197,7 @@ public class CampaignParameterDAO implements ICampaignParameterDAO {
 
     @Override
     public boolean updateCampaignParameter(CampaignParameter campaignParameter) {
-        final StringBuffer query = new StringBuffer("UPDATE `campaignparameter` SET campaign=?, `Parameter`=?, `Value`=? WHERE campaignparameterID=?");
+        final StringBuilder query = new StringBuilder("UPDATE `campaignparameter` SET campaign=?, `Parameter`=?, `Value`=? WHERE campaignparameterID=?");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -230,7 +230,7 @@ public class CampaignParameterDAO implements ICampaignParameterDAO {
 
     @Override
     public boolean createCampaignParameter(CampaignParameter campaignParameter) {
-        final StringBuffer query = new StringBuffer("INSERT INTO `campaignparameter` (`campaign`, `Parameter`, `Value`) VALUES (?, ?, ?);");
+        final StringBuilder query = new StringBuilder("INSERT INTO `campaignparameter` (`campaign`, `Parameter`, `Value`) VALUES (?, ?, ?);");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -263,7 +263,7 @@ public class CampaignParameterDAO implements ICampaignParameterDAO {
     @Override
     public List<CampaignParameter> findCampaignParameterByCriteria(Integer campaignparameterID, String campaign, String parameter, String value) throws CerberusException {
         boolean throwEx = false;
-        final StringBuffer query = new StringBuffer("SELECT * FROM campaignparameter c WHERE 1=1 ");
+        final StringBuilder query = new StringBuilder("SELECT * FROM campaignparameter c WHERE 1=1 ");
 
         if (campaignparameterID != null) {
             query.append(" AND c.campaignparameterID = ?");
@@ -340,7 +340,7 @@ public class CampaignParameterDAO implements ICampaignParameterDAO {
 
     @Override
     public boolean deleteCampaignParameter(CampaignParameter campaignParameter) {
-        final StringBuffer query = new StringBuffer("DELETE FROM `campaignparameter` WHERE campaignparameterID=?");
+        final StringBuilder query = new StringBuilder("DELETE FROM `campaignparameter` WHERE campaignparameterID=?");
 
         Connection connection = this.databaseSpring.connect();
         try {

--- a/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvParamDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvParamDAO.java
@@ -339,7 +339,7 @@ public class CountryEnvParamDAO implements ICountryEnvParamDAO {
 
     @Override
     public void update_deprecated(CountryEnvParam cep) throws CerberusException {
-        final StringBuffer query = new StringBuffer("UPDATE `countryenvparam` SET `build`=?, ");
+        final StringBuilder query = new StringBuilder("UPDATE `countryenvparam` SET `build`=?, ");
         query.append("`revision`=?,`chain`=?, `distriblist`=?, `eMailBodyRevision`=?, `type`=?,`eMailBodyChain`=?,");
         query.append("`eMailBodyDisableEnvironment`=?,  `active`=?, `maintenanceact`=?, `maintenancestr`=?, `maintenanceend`=? ");
         query.append(" where `system`=? and `country`=? and `environment`=? ");
@@ -393,7 +393,7 @@ public class CountryEnvParamDAO implements ICountryEnvParamDAO {
 
     @Override
     public void delete_deprecated(CountryEnvParam cep) throws CerberusException {
-        final StringBuffer query = new StringBuffer("DELETE FROM `countryenvparam` WHERE `system`=? and `country`=? and `environment`=?");
+        final StringBuilder query = new StringBuilder("DELETE FROM `countryenvparam` WHERE `system`=? and `country`=? and `environment`=?");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -424,7 +424,7 @@ public class CountryEnvParamDAO implements ICountryEnvParamDAO {
 
     @Override
     public void create_deprecated(CountryEnvParam cep) throws CerberusException {
-        final StringBuffer query = new StringBuffer("INSERT INTO `countryenvparam` ");
+        final StringBuilder query = new StringBuilder("INSERT INTO `countryenvparam` ");
         query.append("(`system`, `country`, `environment`, `build`, `revision`,`chain`, `distriblist`, `eMailBodyRevision`, `type`,`eMailBodyChain`,");
         query.append("`eMailBodyDisableEnvironment`,  `active`, `maintenanceact`, `maintenancestr`, `maintenanceend`) VALUES ");
         query.append("(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
@@ -1212,7 +1212,7 @@ public class CountryEnvParamDAO implements ICountryEnvParamDAO {
     public Answer update(CountryEnvParam cep) {
         MessageEvent msg = null;
 
-        final StringBuffer query = new StringBuffer("UPDATE `countryenvparam` SET `build`=?, ");
+        final StringBuilder query = new StringBuilder("UPDATE `countryenvparam` SET `build`=?, ");
         query.append("`revision`=?,`chain`=?, `distriblist`=?, `eMailBodyRevision`=?, `type`=?,`eMailBodyChain`=?,");
         query.append("`eMailBodyDisableEnvironment`=?,  `active`=?, `maintenanceact`=?, `maintenancestr`=?, `maintenanceend`=?, `description`=? ");
         query.append(" where `system`=? and `country`=? and `environment`=? ");

--- a/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvironmentDatabaseDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvironmentDatabaseDAO.java
@@ -416,7 +416,7 @@ public class CountryEnvironmentDatabaseDAO implements ICountryEnvironmentDatabas
 
     @Override
     public void update_deprecated(CountryEnvironmentDatabase ced) throws CerberusException {
-        final StringBuffer query = new StringBuffer("UPDATE `countryenvironmentdatabase` SET `connectionpoolname`=? ");
+        final StringBuilder query = new StringBuilder("UPDATE `countryenvironmentdatabase` SET `connectionpoolname`=? ");
         query.append(" where `system`=? and `country`=? and `environment`=? and `database`=?");
 
         Connection connection = this.databaseSpring.connect();
@@ -450,7 +450,7 @@ public class CountryEnvironmentDatabaseDAO implements ICountryEnvironmentDatabas
 
     @Override
     public void delete_deprecated(CountryEnvironmentDatabase ced) throws CerberusException {
-        final StringBuffer query = new StringBuffer("DELETE FROM `countryenvironmentdatabase` WHERE `system`=? and `country`=? and `environment`=? and `database`=?");
+        final StringBuilder query = new StringBuilder("DELETE FROM `countryenvironmentdatabase` WHERE `system`=? and `country`=? and `environment`=? and `database`=?");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -482,7 +482,7 @@ public class CountryEnvironmentDatabaseDAO implements ICountryEnvironmentDatabas
 
     @Override
     public void create_deprecated(CountryEnvironmentDatabase ced) throws CerberusException {
-        final StringBuffer query = new StringBuffer("INSERT INTO `countryenvironmentdatabase` ");
+        final StringBuilder query = new StringBuilder("INSERT INTO `countryenvironmentdatabase` ");
         query.append("(`system`, `country`, `environment`, `database`, `connectionpoolname`) VALUES ");
         query.append("(?,?,?,?,?)");
 

--- a/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvironmentParametersDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/CountryEnvironmentParametersDAO.java
@@ -324,7 +324,7 @@ public class CountryEnvironmentParametersDAO implements ICountryEnvironmentParam
 
     @Override
     public void update_deprecated(CountryEnvironmentParameters cea) throws CerberusException {
-        final StringBuffer query = new StringBuffer("UPDATE `countryenvironmentparameters` SET `IP`=?, ");
+        final StringBuilder query = new StringBuilder("UPDATE `countryenvironmentparameters` SET `IP`=?, ");
         query.append("`URL`=?, `URLLOGIN`=?, `domain`=? ");
         query.append(" where `system`=? and `country`=? and `environment`=? and `application`=?");
 
@@ -362,7 +362,7 @@ public class CountryEnvironmentParametersDAO implements ICountryEnvironmentParam
 
     @Override
     public void delete_deprecated(CountryEnvironmentParameters cea) throws CerberusException {
-        final StringBuffer query = new StringBuffer("DELETE FROM `countryenvironmentparameters` WHERE `system`=? and `country`=? and `environment`=? and `application`=?");
+        final StringBuilder query = new StringBuilder("DELETE FROM `countryenvironmentparameters` WHERE `system`=? and `country`=? and `environment`=? and `application`=?");
 
         Connection connection = this.databaseSpring.connect();
         try {
@@ -394,7 +394,7 @@ public class CountryEnvironmentParametersDAO implements ICountryEnvironmentParam
 
     @Override
     public void create_deprecated(CountryEnvironmentParameters cea) throws CerberusException {
-        final StringBuffer query = new StringBuffer("INSERT INTO `countryenvironmentparameters` ");
+        final StringBuilder query = new StringBuilder("INSERT INTO `countryenvironmentparameters` ");
         query.append("(`system`, `country`, `environment`, `application`, `ip`, `domain`, `url`, `urllogin`) VALUES ");
         query.append("(?,?,?,?,?,?,?,?)");
 

--- a/source/src/main/java/org/cerberus/crud/dao/impl/LogEventDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/LogEventDAO.java
@@ -124,7 +124,7 @@ public class LogEventDAO implements ILogEventDAO {
         List<LogEvent> logEventList = new ArrayList<LogEvent>();
         StringBuilder searchSQL = new StringBuilder();
 
-        final StringBuffer query = new StringBuffer();
+        final StringBuilder query = new StringBuilder();
         //SQL_CALC_FOUND_ROWS allows to retrieve the total number of columns by disrearding the limit clauses that 
         //were applied -- used for pagination p
         query.append("SELECT SQL_CALC_FOUND_ROWS * FROM logevent ");

--- a/source/src/main/java/org/cerberus/service/email/impl/EmailBodyGeneration.java
+++ b/source/src/main/java/org/cerberus/service/email/impl/EmailBodyGeneration.java
@@ -66,7 +66,7 @@ public class EmailBodyGeneration implements IEmailBodyGeneration {
             buildContentTable = buildContentTable + "<thead><tr style=\"background-color:#cad3f1; font-style:bold\"><td>"
                     + "Sprint/Rev</td><td>Application</td><td>Project</td><td>Bug</td><td>Ticket</td><td>People in Charge</td><td>Release Documentation</td></tr></thead><tbody>";
 
-            final String contentSQL = new StringBuffer("SELECT b.`Build`, b.`Revision`, b.`Release` , b.`Link` , ")
+            final String contentSQL = new StringBuilder("SELECT b.`Build`, b.`Revision`, b.`Release` , b.`Link` , ")
                     .append(" b.`Application`, b.`ReleaseOwner`, b.`BugIDFixed`, b.`TicketIDFixed`, b.`subject`, b.`Project`")
                     .append(", p.`VCCode`, u.Name, a.BugTrackerUrl ")
                     .append(" from buildrevisionparameters b ")
@@ -291,7 +291,7 @@ public class EmailBodyGeneration implements IEmailBodyGeneration {
 
                 String bckColor = "#f3f6fa";
                 int a = 1;
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 do {
                     a++;
                     int b;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.