### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/source/src/main/java/org/cerberus/service/engine/impl/PropertyService.java
+++ b/source/src/main/java/org/cerberus/service/engine/impl/PropertyService.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -534,7 +535,7 @@ public class PropertyService implements IPropertyService {
         //means that is library + subdata call -> LIBRARY(ATTRIBUTE) and that we have already the subdata property
         //gets the value for the library entry with basis on
         //the subdataentry specified
-        HashMap<String, TestDataLibResult> currentListResults = tCExecution.getDataLibraryExecutionDataList();
+        Map<String, TestDataLibResult> currentListResults = tCExecution.getDataLibraryExecutionDataList();
 
         TestDataLibResult result = currentListResults.get(keyDataList);
         String subDataValue = result.getValue(tecd.getValue2()); //temporary use of the value2

--- a/source/src/main/java/org/cerberus/service/export/ExportServiceFactory.java
+++ b/source/src/main/java/org/cerberus/service/export/ExportServiceFactory.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -519,7 +520,7 @@ public class ExportServiceFactory {
         return ans;
     }
 
-    private SummaryStatisticsDTO calculateTotalValues(HashMap<String, SummaryStatisticsDTO> summaryMap) {
+    private SummaryStatisticsDTO calculateTotalValues(Map<String, SummaryStatisticsDTO> summaryMap) {
         int okTotal = 0;
         int koTotal = 0;
         int naTotal = 0;

--- a/source/src/main/java/org/cerberus/servlet/crud/countryenvironment/ReadCountryEnvParam.java
+++ b/source/src/main/java/org/cerberus/servlet/crud/countryenvironment/ReadCountryEnvParam.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletException;
@@ -225,7 +226,7 @@ public class ReadCountryEnvParam extends HttpServlet {
 
         JSONArray jsonArray = new JSONArray();
         if (resp.isCodeEquals(MessageEventEnum.DATA_OPERATION_OK.getCode())) {//the service was able to perform the query, then we should get all values
-            HashMap<String, CountryEnvParam> hash = new HashMap<String, CountryEnvParam>();
+            Map<String, CountryEnvParam> hash = new HashMap<String, CountryEnvParam>();
 
             for (CountryEnvParam cep : (List<CountryEnvParam>) resp.getDataList()) {
                 hash.put(cep.getEnvironment(), cep);

--- a/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionGraphByStatus.java
+++ b/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionGraphByStatus.java
@@ -94,7 +94,7 @@ public class CampaignExecutionGraphByStatus extends HttpServlet {
             /**
              * Feed hash map with execution from the two list (to get only one by test,testcase,country,env,browser)
              */
-            HashMap<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
+            Map<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
             SimpleDateFormat formater = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
             
             for (TestCaseWithExecution testCaseWithExecution : testCaseWithExecutions) {
@@ -120,7 +120,7 @@ public class CampaignExecutionGraphByStatus extends HttpServlet {
             testCaseWithExecutions = new ArrayList<TestCaseWithExecution>(testCaseWithExecutionsList.values());
             
             List<JSONObject> axis = new ArrayList<JSONObject>();
-            HashMap<String, Integer> datas = generateMultiBarAxisFromStatus(testCaseWithExecutions);
+            Map<String, Integer> datas = generateMultiBarAxisFromStatus(testCaseWithExecutions);
             
             String color, highlight, status;
             Integer value;

--- a/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionRadarGraphByFunction.java
+++ b/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionRadarGraphByFunction.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -97,7 +98,7 @@ public class CampaignExecutionRadarGraphByFunction extends HttpServlet {
             /**
              * Feed hash map with execution from the two list (to get only one by test,testcase,country,env,browser)
              */
-            HashMap<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
+            Map<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
             SimpleDateFormat formater = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
             
             for (TestCaseWithExecution testCaseWithExecution : testCaseWithExecutions) {
@@ -122,7 +123,7 @@ public class CampaignExecutionRadarGraphByFunction extends HttpServlet {
              }
             testCaseWithExecutions = new ArrayList<TestCaseWithExecution>(testCaseWithExecutionsList.values());
             
-            HashMap<String, List<String>> datas = generateMultiBarAxisFromStatus(testCaseWithExecutions);
+            Map<String, List<String>> datas = generateMultiBarAxisFromStatus(testCaseWithExecutions);
 
             List<JSONObject> axis = new ArrayList<JSONObject>();
             

--- a/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionReport.java
+++ b/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionReport.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.ServletException;
@@ -97,7 +98,7 @@ public class CampaignExecutionReport extends HttpServlet {
              * Feed hash map with execution from the two list (to get only one
              * by test,testcase,country,env,browser)
              */
-            HashMap<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
+            Map<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
             SimpleDateFormat formater = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 
             for (TestCaseWithExecution testCaseWithExecution : testCaseWithExecutions) {
@@ -122,8 +123,8 @@ public class CampaignExecutionReport extends HttpServlet {
             }
             testCaseWithExecutions = new ArrayList<TestCaseWithExecution>(testCaseWithExecutionsList.values());
 
-            HashMap<String, JSONObject> ttc = new HashMap<String, JSONObject>();
-            HashMap<String, JSONObject> ceb = new HashMap<String, JSONObject>();
+            Map<String, JSONObject> ttc = new HashMap<String, JSONObject>();
+            Map<String, JSONObject> ceb = new HashMap<String, JSONObject>();
             for (TestCaseWithExecution testCaseWithExecution : testCaseWithExecutions) {
                 try {
                     executionList.put(testCaseExecutionToJSONObject(testCaseWithExecution));

--- a/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionStatusBarGraphByFunction.java
+++ b/source/src/main/java/org/cerberus/servlet/crud/testcampaign/CampaignExecutionStatusBarGraphByFunction.java
@@ -26,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -102,7 +103,7 @@ public class CampaignExecutionStatusBarGraphByFunction extends HttpServlet {
             /**
              * Feed hash map with execution from the two list (to get only one by test,testcase,country,env,browser)
              */
-            HashMap<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
+            Map<String, TestCaseWithExecution> testCaseWithExecutionsList = new HashMap();
             SimpleDateFormat formater = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
             
             for (TestCaseWithExecution testCaseWithExecution : testCaseWithExecutions) {
@@ -127,7 +128,7 @@ public class CampaignExecutionStatusBarGraphByFunction extends HttpServlet {
              }
             testCaseWithExecutions = new ArrayList<TestCaseWithExecution>(testCaseWithExecutionsList.values());
             
-            HashMap<String, List<String>> datas = generateMultiBarAxisFromStatus(testCaseWithExecutions);
+            Map<String, List<String>> datas = generateMultiBarAxisFromStatus(testCaseWithExecutions);
 
             List<JSONObject> axis = new ArrayList<JSONObject>();
             

--- a/source/src/main/java/org/cerberus/servlet/guipages/ExecutionPerBuildRevision.java
+++ b/source/src/main/java/org/cerberus/servlet/guipages/ExecutionPerBuildRevision.java
@@ -116,9 +116,9 @@ public class ExecutionPerBuildRevision extends HttpServlet {
 
                 List<BuildRevisionStatistics> buildRev = tceStatsService.getListOfXLastBuildAndRev(MySystem, numberOfLastBR, sprint);
 
-                ArrayList<ArrayList<String>> arrayBuildRevision = new ArrayList<ArrayList<String>>();
+                List<ArrayList<String>> arrayBuildRevision = new ArrayList<ArrayList<String>>();
                 List<List<List<String>>> arrayBuildRevisionEnv = new ArrayList<List<List<String>>>();
-                ArrayList<ArrayList<ArrayList<String>>> arrayBuildRevisionContent = new ArrayList<ArrayList<ArrayList<String>>>();
+                List<ArrayList<ArrayList<String>>> arrayBuildRevisionContent = new ArrayList<ArrayList<ArrayList<String>>>();
 
                 for (BuildRevisionStatistics buildRevList : buildRev) {
                     //ITestCaseExecutionStatisticsService tceStatsS = appContext.getBean(ITestCaseExecutionStatisticsService.class);

--- a/source/src/main/java/org/cerberus/servlet/guipages/FindTestImplementationStatusPerApplication.java
+++ b/source/src/main/java/org/cerberus/servlet/guipages/FindTestImplementationStatusPerApplication.java
@@ -137,7 +137,7 @@ public class FindTestImplementationStatusPerApplication extends HttpServlet {
                 ResultSet rs_teststatus = stmt_teststatus.executeQuery();
 
 //                Integer tot = 0;
-                ArrayList<Integer> totLine;
+                List<Integer> totLine;
                 totLine = new ArrayList<Integer>();
                 for (Invariant i : myInvariants) {
                     totLine.add(0);

--- a/source/src/main/java/org/cerberus/servlet/reporting/GetReportData.java
+++ b/source/src/main/java/org/cerberus/servlet/reporting/GetReportData.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -95,7 +96,7 @@ public class GetReportData extends HttpServlet {
 
         if (!split) {
 
-            HashMap<String, JSONObject> axisMap = new HashMap<String, JSONObject>();
+            Map<String, JSONObject> axisMap = new HashMap<String, JSONObject>();
 
             for (TestCaseWithExecution testCaseWithExecution : testCaseWithExecutions) {
                 String key;
@@ -141,7 +142,7 @@ public class GetReportData extends HttpServlet {
             AnswerList columnQueue = testCaseExecutionInQueueService.readDistinctColumnByTag(tag, env, country, browser, app);
             List<TestCaseWithExecution> columnInQueue = columnQueue.getDataList();
 
-            LinkedHashMap<String, TestCaseWithExecution> testCaseWithExecutionsList = new LinkedHashMap();
+            Map<String, TestCaseWithExecution> testCaseWithExecutionsList = new LinkedHashMap();
 
             for (TestCaseWithExecution column : columnTcExec) {
                 String key = column.getBrowser()
@@ -237,7 +238,7 @@ public class GetReportData extends HttpServlet {
     }// </editor-fold>
 
     private List<TestCaseWithExecution> hashExecution(List<TestCaseWithExecution> testCaseWithExecutions, List<TestCaseWithExecution> testCaseWithExecutionsInQueue) throws ParseException {
-        LinkedHashMap<String, TestCaseWithExecution> testCaseWithExecutionsList = new LinkedHashMap();
+        Map<String, TestCaseWithExecution> testCaseWithExecutionsList = new LinkedHashMap();
         SimpleDateFormat formater = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
 
         for (TestCaseWithExecution testCaseWithExecution : testCaseWithExecutions) {

--- a/source/src/main/java/org/cerberus/servlet/zzpublic/GetCampaignExecutionsCommand.java
+++ b/source/src/main/java/org/cerberus/servlet/zzpublic/GetCampaignExecutionsCommand.java
@@ -190,7 +190,7 @@ public class GetCampaignExecutionsCommand extends HttpServlet {
     }
 
     private List<String> convertParametersListToListOfQueries(List<CampaignParameter> campaignParameterList, List<String> queries) {
-        HashMap<String, List<String>> hmParametersValues = new HashMap<String, List<String>>();
+        Map<String, List<String>> hmParametersValues = new HashMap<String, List<String>>();
 
         for (CampaignParameter campaignParameter : campaignParameterList) {
             if (campaignParameter.getParameter() != null && campaignParameter.getValue() != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.