### PR TITLE
Fix deploy script missing command and add update instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -53,3 +53,22 @@ You can use the start-selenium.sh script in tools/selenium/ folder. Update it in
 Script execution automation can be done using the scripts located in tools/batchexecution/.
  
 NB : don't forget to update the cerberus parameters according to your Environment --> parameter page in Admin menu needs to be changed according to your local config (See CerberusPicturesConfig file inside docs folder).
+
+Update
+------
+
+0) Download and unzip(tar) Cerberus package
+
+1) [Optional] Backup database
+
+- mysqldump -u cerberus -p cerberus > CerberusBddBackup.sql
+
+2) Modify 00Config.sh file with your local parameters. Tips: you can copy file from previous installation.
+
+3) Deploy Cerberus Application
+
+- run deploy script --> 02DeployApp.sh[.bat]
+
+4) You can connect to cerberus. 
+- The first connection will invite you to update the database.
+- You can start to using Cerberus.

--- a/bin/02DeployApp.bat
+++ b/bin/02DeployApp.bat
@@ -18,5 +18,6 @@ CALL %GLASSFISHPATH%asadmin undeploy --target server --cascade=true Cerberus-1.1
 CALL %GLASSFISHPATH%asadmin undeploy --target server --cascade=true Cerberus-1.1.1
 CALL %GLASSFISHPATH%asadmin undeploy --target server --cascade=true Cerberus-1.1.1
 CALL %GLASSFISHPATH%asadmin undeploy --target server --cascade=true Cerberus-1.1.2
+CALL %GLASSFISHPATH%asadmin undeploy --target server --cascade=true Cerberus-1.1.3
 CALL %GLASSFISHPATH%asadmin undeploy --target server --cascade=true Cerberus-1.1.4
 CALL %GLASSFISHPATH%asadmin deploy --target server --contextroot Cerberus --availabilityenabled=true %MYPATH%\..\Cerberus-1.1.4.war

--- a/bin/02DeployApp.sh
+++ b/bin/02DeployApp.sh
@@ -18,6 +18,7 @@ $GLASSFISHPATH/asadmin undeploy --target server --cascade=true Cerberus-1.1.0
 $GLASSFISHPATH/asadmin undeploy --target server --cascade=true Cerberus-1.1.1
 $GLASSFISHPATH/asadmin undeploy --target server --cascade=true Cerberus-1.1.1
 $GLASSFISHPATH/asadmin undeploy --target server --cascade=true Cerberus-1.1.2
+$GLASSFISHPATH/asadmin undeploy --target server --cascade=true Cerberus-1.1.3
 $GLASSFISHPATH/asadmin undeploy --target server --cascade=true Cerberus-1.1.4
 $GLASSFISHPATH/asadmin deploy --target server --contextroot Cerberus --availabilityenabled=true $MYPATH/../Cerberus-1.1.4.war
 


### PR DESCRIPTION
Hi,
By updating my cerberus installation to v1.1.4, I saw missing commands in the deploy script.
I add too some basic instructions to update a cerberus installation.
Hope it helps