### PR TITLE
Null Pointer Exception correction

### DIFF
--- a/source/src/main/java/org/cerberus/crud/service/impl/ParameterService.java
+++ b/source/src/main/java/org/cerberus/crud/service/impl/ParameterService.java
@@ -152,7 +152,7 @@ public class ParameterService implements IParameterService {
     private void firePropertyChange(Parameter parameter) {
         Set<ParameterAware> existingRegistration;
         synchronized (propertyRegistration) {
-            existingRegistration = new HashSet<>(propertyRegistration.get(parameter.getParam()));
+            existingRegistration = propertyRegistration.get(parameter.getParam());
         }
         if (existingRegistration != null) {
             for (ParameterAware parameterAware : existingRegistration) {


### PR DESCRIPTION
When we try to update a parameter in the current version, it update the value in database but shows "Unable to update the Cell"
It is because there is an Null pointer exception which is thrown when you fire property change. 

propertyRegistration.get() can be null and already return a Set<ParameterAware>
But new HashSet<>(null) throws NullPointerException. 

That's why I suggest to remove the new HashSet that has no purpose here.